### PR TITLE
Add a repos file for ros-infrastructure packages

### DIFF
--- a/constraints-heads.txt
+++ b/constraints-heads.txt
@@ -1,3 +1,4 @@
+# Should mirror ros-infrastructure.repos
 bloom@ git+https://github.com/ros-infrastructure/bloom.git
 catkin-pkg@ git+https://github.com/ros-infrastructure/catkin_pkg.git
 catkin-sphinx@ git+https://github.com/ros-infrastructure/catkin-sphinx.git

--- a/ros-infrastructure.repos
+++ b/ros-infrastructure.repos
@@ -1,0 +1,43 @@
+---
+# Should mirror constraints-heads.txt
+repositories:
+  bloom:
+    type: git
+    url: https://github.com/ros-infrastructure/bloom.git
+    version: master
+  catkin-pkg:
+    type: git
+    url: https://github.com/ros-infrastructure/catkin_pkg.git
+    version: master
+  catkin-sphinx:
+    type: git
+    url: https://github.com/ros-infrastructure/catkin-sphinx.git
+    version: master
+  ros-buildfarm:
+    type: git
+    url: https://github.com/ros-infrastructure/ros_buildfarm.git
+    version: master
+  rosdep:
+    type: git
+    url: https://github.com/ros-infrastructure/rosdep.git
+    version: master
+  rosdistro:
+    type: git
+    url: https://github.com/ros-infrastructure/rosdistro.git
+    version: master
+  rosdoc2:
+    type: git
+    url: https://github.com/ros-infrastructure/rosdoc2.git
+    version: main
+  rosinstall-generator:
+    type: git
+    url: https://github.com/ros-infrastructure/rosinstall_generator.git
+    version: master
+  rospkg:
+    type: git
+    url: https://github.com/ros-infrastructure/rospkg.git
+    version: master
+  superflore:
+    type: git
+    url: https://github.com/ros-infrastructure/superflore.git
+    version: master

--- a/ros-infrastructure.repos
+++ b/ros-infrastructure.repos
@@ -5,7 +5,7 @@ repositories:
     type: git
     url: https://github.com/ros-infrastructure/bloom.git
     version: master
-  catkin-pkg:
+  catkin_pkg:
     type: git
     url: https://github.com/ros-infrastructure/catkin_pkg.git
     version: master
@@ -13,7 +13,7 @@ repositories:
     type: git
     url: https://github.com/ros-infrastructure/catkin-sphinx.git
     version: master
-  ros-buildfarm:
+  ros_buildfarm:
     type: git
     url: https://github.com/ros-infrastructure/ros_buildfarm.git
     version: master
@@ -29,7 +29,7 @@ repositories:
     type: git
     url: https://github.com/ros-infrastructure/rosdoc2.git
     version: main
-  rosinstall-generator:
+  rosinstall_generator:
     type: git
     url: https://github.com/ros-infrastructure/rosinstall_generator.git
     version: master


### PR DESCRIPTION
This isn't used by the CI automation defined here, but will be used by other CI automation to test HEAD of all of our packages together.

As requested here: https://github.com/ros2/ros_buildfarm_config/pull/308#discussion_r1657623290