### PR TITLE
Add more repos to check

### DIFF
--- a/constraints-heads.txt
+++ b/constraints-heads.txt
@@ -2,10 +2,15 @@
 bloom@ git+https://github.com/ros-infrastructure/bloom.git
 catkin-pkg@ git+https://github.com/ros-infrastructure/catkin_pkg.git
 catkin-sphinx@ git+https://github.com/ros-infrastructure/catkin-sphinx.git
+createrepo-agent@ git+https://github.com/osrf/createrepo-agent.git
+osrf-pycommon@ git+https://github.com/osrf/osrf_pycommon.git
+rocker@ git+https://github.com/osrf/rocker.git
 ros-buildfarm@ git+https://github.com/ros-infrastructure/ros_buildfarm.git
 rosdep@ git+https://github.com/ros-infrastructure/rosdep.git
 rosdistro@ git+https://github.com/ros-infrastructure/rosdistro.git
+rosdistro-reviewer@ git+https://github.com/ros-infrastructure/rosdistro-reviewer.git
 rosdoc2@ git+https://github.com/ros-infrastructure/rosdoc2.git
 rosinstall-generator@ git+https://github.com/ros-infrastructure/rosinstall_generator.git
 rospkg@ git+https://github.com/ros-infrastructure/rospkg.git
 superflore@ git+https://github.com/ros-infrastructure/superflore.git
+vcs2l@ git+https://github.com/ros-infrastructure/vcs2l.git

--- a/ros-infrastructure.repos
+++ b/ros-infrastructure.repos
@@ -13,6 +13,18 @@ repositories:
     type: git
     url: https://github.com/ros-infrastructure/catkin-sphinx.git
     version: master
+  createrepo-agent:
+    type: git
+    url: https://github.com/osrf/createrepo-agent.git
+    version: main
+  osrf_pycommon:
+    type: git
+    url: https://github.com/osrf/osrf_pycommon.git
+    version: master
+  rocker:
+    type: git
+    url: https://github.com/osrf/rocker.git
+    version: main
   ros_buildfarm:
     type: git
     url: https://github.com/ros-infrastructure/ros_buildfarm.git
@@ -25,6 +37,10 @@ repositories:
     type: git
     url: https://github.com/ros-infrastructure/rosdistro.git
     version: master
+  rosdistro-reviewer:
+    type: git
+    url: https://github.com/ros-infrastructure/rosdistro-reviewer.git
+    version: main
   rosdoc2:
     type: git
     url: https://github.com/ros-infrastructure/rosdoc2.git


### PR DESCRIPTION
Requires ros2/ros_buildfarm_config#358

Test build: [![Build Status](https://build.ros2.org/buildStatus/icon?job=ci__infra_ubuntu_resolute_amd64&build=12)](https://build.ros2.org/view/ci/job/ci__infra_ubuntu_resolute_amd64/12/)

There is one test that is not passing with these additional packages in Rocker, which we should address out-of-band:
```
=================================== FAILURES ===================================
____________________ UserExtensionTest.test_user_extension _____________________
test/test_extension.py:421: in test_user_extension
    self.assertTrue('usermod -aG' in snippet_result)
E   AssertionError: False is not true
---------- generated xml file: /tmp/ws/test_results/rocker/pytest.xml ----------
=========================== short test summary info ============================
FAILED test/test_extension.py::UserExtensionTest::test_user_extension - Asser...
================= 1 failed, 50 passed, 33 deselected in 0.63s ==================
```

(note that we're already skipping the Docker-based Rocker tests that can't run in this context with `-m "not docker"`)